### PR TITLE
feat: add sentence-level streaming TTS endpoint for real-time voice a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Welcome to **openai-f5-tts**! This project provides a user-friendly Flask-based 
   - [Prerequisites](#prerequisites-1)
   - [Installation Steps](#installation-steps)
 - [API Endpoints](#api-endpoints)
+  - [POST /v1/audio/speech](#v1audiospeech)
+  - [POST /v1/audio/speech/stream](#v1audiospeechstream)
+  - [GET /v1/models](#v1models)
+  - [GET /v1/voices](#v1voices)
+  - [GET /v1/voices/all](#v1voicesall)
+- [Streaming Test Client](#streaming-test-client)
 - [Adding Your Own Fine-Tuned Checkpoint](#adding-your-own-fine-tuned-checkpoint)
 - [TODO](#todo)
 - [Support](#support)
@@ -267,33 +273,55 @@ The API will be accessible at `http://localhost:9090`.
 
 ### `/v1/audio/speech`
 
-Primary route for generating speech from text input. Requires an API key in the request header as a Bearer token.
+Generates speech from text and returns a complete audio file. OpenAI-compatible.
 
-- **URL**: `/v1/audio/speech`
 - **Method**: `POST`
 - **Headers**: `Authorization: Bearer <API_KEY>`
-- **Data (JSON)**:
-  - `input` (string): The text to convert to speech.
-  - `voice` (string, optional): Voice model to use (default: "Emilia").
-  - `response_format` (string, optional): Output audio format (default: `mp3`).
-  - `speed` (float, optional): Speech speed adjustment factor.
-  - `ref_audio` (string, optional): Path to a reference audio file.
-
-- **Response**: An audio file in the specified format.
-
-**Example:**
+- **Body (JSON)**:
+  - `input` (string): Text to convert to speech.
+  - `voice` (string, optional): Voice model to use (default: `Emilia`).
+  - `response_format` (string, optional): Output format — `mp3`, `wav`, `flac`, etc. (default: `mp3`).
+  - `speed` (float, optional): Speed factor (default: `1.0`).
+- **Response**: Audio file in the requested format.
 
 ```bash
 curl -X POST http://localhost:9090/v1/audio/speech \
      -H "Authorization: Bearer <API_KEY>" \
      -H "Content-Type: application/json" \
-     -d '{
-           "input": "Hello world",
-           "voice": "Emilia",
-           "response_format": "mp3",
-           "speed": 1.0
-         }' > output.mp3
+     -d '{"input": "Hello world", "voice": "Emilia", "response_format": "mp3"}' \
+     > output.mp3
 ```
+
+---
+
+### `/v1/audio/speech/stream`
+
+Streams speech as raw **int16 PCM at 16 kHz** using chunked transfer encoding. Designed for real-time voice agent pipelines (e.g. Hugging Face speech-to-speech).
+
+The input text is split into sentences using an NLTK tokenizer. Each sentence is synthesised by F5-TTS and flushed to the client immediately, so playback can begin before the full response is ready. Dropping the HTTP connection mid-stream stops further synthesis — useful for barge-in handling.
+
+- **Method**: `POST`
+- **Headers**: `Authorization: Bearer <API_KEY>`
+- **Body (JSON)**:
+  - `input` (string): Text to synthesise.
+  - `voice` (string, optional): Voice model to use (default: `Emilia`).
+  - `speed` (float, optional): Speed factor (default: `1.0`).
+- **Response**:
+  - `Content-Type: audio/L16`
+  - `X-Sample-Rate: 16000`
+  - `X-Audio-Channels: 1`
+  - `X-Audio-Encoding: int16`
+  - Body: raw little-endian int16 PCM, one chunk per sentence.
+
+```bash
+curl -X POST http://localhost:9090/v1/audio/speech/stream \
+     -H "Authorization: Bearer <API_KEY>" \
+     -H "Content-Type: application/json" \
+     -d '{"input": "Hello. This streams sentence by sentence.", "voice": "Emilia"}' \
+     > output.pcm
+```
+
+> **Note**: F5-TTS is non-autoregressive — full per-sentence inference is required before each chunk can be sent. Latency to first audio is roughly the time to synthesise the first sentence (~1–2 s on GPU).
 
 ### `/v1/models`
 
@@ -323,6 +351,31 @@ Lists all supported voices, regardless of language.
 - **Method**: `GET`
 - **Headers**: `Authorization: Bearer <API_KEY>`
 - **Response**: JSON containing all supported voices.
+
+---
+
+## Streaming Test Client
+
+`test_stream_client.py` in the project root hits the streaming endpoint and writes the received PCM to a WAV file for verification.
+
+```bash
+python test_stream_client.py \
+  --text "Hello. The quick brown fox jumps over the lazy dog. Streaming works." \
+  --voice Emilia \
+  --output stream_test.wav
+```
+
+Options:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `localhost` | Server hostname |
+| `--port` | `9090` | Server port |
+| `--api-key` | `$API_KEY` env var | Bearer token |
+| `--voice` | `$DEFAULT_VOICE` env var | Voice name |
+| `--speed` | `1.0` | Speed factor |
+| `--text` | built-in sample | Text to synthesise |
+| `--output` | `stream_test_output.wav` | Output WAV path |
 
 ---
 
@@ -403,6 +456,7 @@ curl -X POST http://localhost:9090/v1/audio/speech \
 - [x] Expose OpenAI-compatible endpoint
 - [x] Fix Docker + CUDA compatibility
 - [x] Multiple voice models
+- [x] Streaming endpoint for real-time voice agent pipelines
 - [ ] Add expression parsing for nuanced speech
 - [ ] Document usage for fine-tuned models
 - [ ] Enhance error handling and logging

--- a/app/server.py
+++ b/app/server.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from flask import Flask, request, send_file, jsonify
+from flask import Flask, request, send_file, jsonify, Response, stream_with_context
 from gevent.pywsgi import WSGIServer
 from dotenv import load_dotenv
 from argparse import ArgumentParser
@@ -119,6 +119,56 @@ def text_to_speech():
     except Exception as e:
         logging.error(f"Unhandled exception during TTS generation: {e}")
         return jsonify({"error": "Failed to generate speech"}), 500
+
+@app.route('/v1/audio/speech/stream', methods=['POST'])
+@require_api_key
+def text_to_speech_stream():
+    """
+    Stream speech as raw int16 PCM at 16 kHz using chunked transfer encoding.
+    Text is split into sentences; each sentence is synthesised and flushed as it
+    completes. Dropping the connection mid-stream stops further synthesis.
+
+    Request body (JSON):
+      - input: Text to synthesise.
+      - voice: (Optional) Voice name. Defaults to DEFAULT_VOICE.
+      - speed: (Optional) Speed factor. Defaults to DEFAULT_SPEED.
+
+    Response:
+      Content-Type: audio/L16
+      X-Sample-Rate: 16000
+      X-Audio-Channels: 1
+      X-Audio-Encoding: int16
+    """
+    data = request.json
+    if not data or 'input' not in data:
+        return jsonify({"error": "Missing 'input' in request body"}), 400
+
+    text = data.get('input')
+    voice = data.get('voice') or DEFAULT_VOICE
+    speed = float(data.get('speed', DEFAULT_SPEED))
+
+    def generate():
+        try:
+            for chunk in tts_handler.generate_speech_stream(text, voice, speed):
+                yield chunk
+        except ValueError as e:
+            logging.error(f"Stream ValueError: {e}")
+        except RuntimeError as e:
+            logging.error(f"Stream RuntimeError: {e}")
+        except Exception as e:
+            logging.error(f"Unhandled stream exception: {e}")
+
+    headers = {
+        'X-Sample-Rate': '16000',
+        'X-Audio-Channels': '1',
+        'X-Audio-Encoding': 'int16',
+    }
+    return Response(
+        stream_with_context(generate()),
+        mimetype='audio/L16',
+        headers=headers
+    )
+
 
 @app.route('/v1/models', methods=['GET'])
 @require_api_key

--- a/app/tts_handler.py
+++ b/app/tts_handler.py
@@ -11,6 +11,7 @@ import gc  # Import garbage collection
 from collections import OrderedDict
 from safetensors.torch import save_file, load_file
 from transformers import WhisperProcessor, WhisperForConditionalGeneration
+import nltk
 from f5_tts.model import DiT
 from f5_tts.infer.utils_infer import (
     load_vocoder,
@@ -20,6 +21,11 @@ from f5_tts.infer.utils_infer import (
     remove_silence_for_generated_wav
 )
 from utils import AUDIO_FORMAT_MIME_TYPES
+
+try:
+    nltk.data.find('tokenizers/punkt_tab')
+except LookupError:
+    nltk.download('punkt_tab', quiet=True)
 
 # Initialize logging
 logging.basicConfig(level=logging.INFO)
@@ -49,6 +55,7 @@ class TTSHandler:
         self.retain_cache = retain_cache
         self.disable_pcm_normalization = disable_pcm_normalization
         self.default_voice = default_voice
+        self._ref_text_cache: dict = {}
 
         self.cleanup_cache()
         self.processor, self.whisper_model = self.load_whisper_model()
@@ -324,6 +331,7 @@ class TTSHandler:
     def transcribe_audio(self, voice_name):
         """
         Transcribes the reference audio file for a given voice using Whisper.
+        Result is cached in memory so Whisper only runs once per voice per server lifetime.
 
         Args:
             voice_name (str): The name of the voice.
@@ -331,14 +339,16 @@ class TTSHandler:
         Returns:
             str: Transcription text.
         """
+        if voice_name in self._ref_text_cache:
+            logging.debug(f"Using cached transcription for voice '{voice_name}'.")
+            return self._ref_text_cache[voice_name]
+
         logging.info(f"Transcribing reference audio for voice '{voice_name}'...")
         processed_audio_path = self.process_reference_audio(voice_name)
 
-        # Read the processed audio
         audio_input, sample_rate = sf.read(processed_audio_path)
         logging.debug(f"Processed audio loaded: {processed_audio_path} with sample rate {sample_rate}")
 
-        # Process audio as input features for Whisper
         inputs = self.processor(audio_input, sampling_rate=16000, return_tensors="pt").input_features.to(self.device)
 
         with torch.no_grad():
@@ -346,6 +356,7 @@ class TTSHandler:
 
         transcription = self.processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
         logging.debug(f"Transcription result: {transcription}")
+        self._ref_text_cache[voice_name] = transcription
         return transcription
 
     def infer(self, gen_text, voice_name, model):
@@ -419,3 +430,49 @@ class TTSHandler:
         except Exception as e:
             logging.error(f"Error in generate_speech: {e}")
             raise RuntimeError("Failed to generate speech.")
+
+    def generate_speech_stream(self, text, voice='Emilia', speed=1.0):
+        """
+        Generator that splits text into sentences and yields int16 PCM bytes at 16 kHz
+        as each sentence is synthesised. Loads the model and reference data once before
+        the loop so neither is reloaded per sentence.
+
+        Args:
+            text (str): Full text to synthesise.
+            voice (str): Voice name.
+            speed (float): Speed adjustment factor.
+
+        Yields:
+            bytes: Raw int16 little-endian PCM audio at 16 kHz, one chunk per sentence.
+        """
+        if not text:
+            raise ValueError("No text provided for TTS generation.")
+        if voice not in self.available_models:
+            raise ValueError(f"Voice '{voice}' is not available.")
+
+        model = self.load_voice_model(voice)
+        ref_text = self.transcribe_audio(voice)
+        ref_audio_path = self.process_reference_audio(voice)
+
+        sentences = nltk.sent_tokenize(text)
+        logging.info(f"Streaming {len(sentences)} sentence(s) for voice '{voice}'.")
+
+        try:
+            for sentence in sentences:
+                sentence = sentence.strip()
+                if not sentence:
+                    continue
+                logging.debug(f"Synthesising sentence: {sentence}")
+                final_wave, final_sample_rate, _ = infer_process(
+                    ref_audio_path, ref_text, sentence, model, self.vocoder,
+                    cross_fade_duration=0.15, speed=speed
+                )
+                audio = final_wave.squeeze().cpu().numpy() if isinstance(final_wave, torch.Tensor) else final_wave.squeeze()
+
+                if final_sample_rate != 16000:
+                    audio = librosa.resample(audio, orig_sr=final_sample_rate, target_sr=16000)
+
+                pcm = (np.clip(audio, -1.0, 1.0) * 32767).astype(np.int16)
+                yield pcm.tobytes()
+        except GeneratorExit:
+            logging.info(f"Client disconnected — stopping stream for voice '{voice}'.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,6 @@ transformers>=4.46.2
 torch>=2.0.0
 librosa>=0.9.2
 soundfile>=0.11.0
+nltk>=3.8.0
+requests>=2.28.0
 

--- a/test_stream_client.py
+++ b/test_stream_client.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Test client for the /v1/audio/speech/stream endpoint.
+
+Streams int16 PCM from the server and writes a valid WAV file for playback verification.
+
+Usage:
+    python test_stream_client.py [--host HOST] [--port PORT] [--voice VOICE]
+                                 [--text TEXT] [--output OUTPUT]
+"""
+import argparse
+import struct
+import wave
+import requests
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SAMPLE_RATE = 16000
+CHANNELS = 1
+SAMPLE_WIDTH = 2  # int16 = 2 bytes
+
+
+def stream_to_wav(host, port, api_key, text, voice, speed, output_path):
+    url = f"http://{host}:{port}/v1/audio/speech/stream"
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    payload = {"input": text, "voice": voice, "speed": speed}
+
+    print(f"Connecting to {url} ...")
+    chunks = []
+    with requests.post(url, json=payload, headers=headers, stream=True, timeout=120) as resp:
+        resp.raise_for_status()
+        reported_rate = resp.headers.get("X-Sample-Rate", str(SAMPLE_RATE))
+        print(f"Server sample rate: {reported_rate} Hz — receiving chunks ...")
+        for chunk in resp.iter_content(chunk_size=None):
+            if chunk:
+                chunks.append(chunk)
+                print(f"  received {len(chunk)} bytes (total {sum(len(c) for c in chunks)})", end="\r")
+
+    pcm_data = b"".join(chunks)
+    print(f"\nTotal PCM received: {len(pcm_data)} bytes "
+          f"({len(pcm_data) / (SAMPLE_RATE * CHANNELS * SAMPLE_WIDTH):.2f}s)")
+
+    with wave.open(output_path, "wb") as wf:
+        wf.setnchannels(CHANNELS)
+        wf.setsampwidth(SAMPLE_WIDTH)
+        wf.setframerate(int(reported_rate))
+        wf.writeframes(pcm_data)
+
+    print(f"WAV written to: {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stream TTS to WAV file")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=int(os.getenv("PORT", 9090)))
+    parser.add_argument("--api-key", default=os.getenv("API_KEY", "your_api_key_here"))
+    parser.add_argument("--voice", default=os.getenv("DEFAULT_VOICE", "Emilia"))
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument(
+        "--text",
+        default=(
+            "Hello, this is a streaming test. "
+            "The quick brown fox jumps over the lazy dog. "
+            "Streaming synthesis processes one sentence at a time."
+        ),
+    )
+    parser.add_argument("--output", default="stream_test_output.wav")
+    args = parser.parse_args()
+
+    stream_to_wav(
+        host=args.host,
+        port=args.port,
+        api_key=args.api_key,
+        text=args.text,
+        voice=args.voice,
+        speed=args.speed,
+        output_path=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I've been using your api wrapper for some time and I love it. I'm currently working on a realtime shim to put in front of STT ->LLM  ->TTS based on the Hugging Face repo and I want to use the endpoints I have rather than the HF models, so I made this addition to openai-f5-tts. The stream endpoint is standard openai output format that a realtime endpoint uses.

Anyways, thought I'd contribute if you want it. All is tested and the audio/speech endpoint is unaffected by additions and the new stream endpint works nicely as well.

Cheers

- POST /v1/audio/speech/stream streams raw int16 PCM at 16 kHz via chunked transfer; text is split by NLTK sent_tokenize and each sentence is synthesised then flushed immediately
- Client disconnect mid-stream stops further GPU inference (barge-in support) via GeneratorExit handling in the generator
- Cache Whisper transcription per voice in _ref_text_cache so Whisper runs once per voice lifetime instead of once per request (also improves batch path)
- Add test_stream_client.py: streams from the endpoint and writes a WAV file
- Add nltk>=3.8.0 and requests>=2.28.0 to requirements.txt
- Update README with streaming endpoint docs, test client usage, and TODO entry