### PR TITLE
Optional ElevenLabs-shaped timestamps with graceful fallback

### DIFF
--- a/app/alignment.py
+++ b/app/alignment.py
@@ -1,0 +1,115 @@
+
+"""Optional ElevenLabs-shaped character alignment.
+
+Prior behaviour is unchanged: /v1/audio/speech still returns raw audio.
+This module must import with zero extra packages. A real aligner (WhisperX,
+etc.) is used only if it is already installed; otherwise we fall back to
+duration-weighted estimates, then to null alignment.
+"""
+from __future__ import annotations
+
+import logging
+
+_VOWELS = set("aeiouAEIOU")
+
+try:
+    import soundfile as sf
+except Exception:  # pragma: no cover
+    sf = None
+
+
+def _char_weight(ch: str) -> float:
+    if ch.isspace():
+        return 0.28
+    if ch in ",;:":
+        return 0.35
+    if ch in ".!?":
+        return 0.55
+    if ch in _VOWELS:
+        return 1.25
+    if ch.isalpha():
+        return 1.0
+    return 0.4
+
+
+def estimate_alignment(text: str, duration_s: float) -> dict:
+    if not text:
+        return {
+            "characters": [],
+            "character_start_times_seconds": [],
+            "character_end_times_seconds": [],
+        }
+    chars = list(text)
+    weights = [_char_weight(c) for c in chars]
+    total = sum(weights) or float(len(chars))
+    duration_s = max(float(duration_s), 0.01)
+    starts, ends = [], []
+    t = 0.0
+    for w in weights:
+        dt = duration_s * (w / total)
+        starts.append(round(t, 4))
+        t += dt
+        ends.append(round(t, 4))
+    ends[-1] = round(duration_s, 4)
+    return {
+        "characters": chars,
+        "character_start_times_seconds": starts,
+        "character_end_times_seconds": ends,
+    }
+
+
+def words_from_alignment(alignment: dict) -> list:
+    chars = alignment["characters"]
+    starts = alignment["character_start_times_seconds"]
+    ends = alignment["character_end_times_seconds"]
+    words = []
+    buf, i0 = [], None
+    for i, ch in enumerate(chars):
+        if ch.isspace() or ch in ".,!?;:":
+            if buf and i0 is not None:
+                words.append({"word": "".join(buf), "start": starts[i0], "end": ends[i - 1]})
+                buf, i0 = [], None
+            continue
+        if i0 is None:
+            i0 = i
+        buf.append(ch)
+    if buf and i0 is not None:
+        words.append({"word": "".join(buf), "start": starts[i0], "end": ends[len(chars) - 1]})
+    return words
+
+
+def _try_whisperx(audio_path: str, text: str):
+    try:
+        import whisperx  # noqa: F401
+    except Exception:
+        return None
+    logging.info("whisperx is installed; duration-weighted alignment still used (no forced-align hook yet).")
+    return None
+
+
+def audio_duration_seconds(audio_path: str) -> float | None:
+    if sf is None:
+        return None
+    try:
+        info = sf.info(audio_path)
+        if info.frames and info.samplerate:
+            return float(info.frames) / float(info.samplerate)
+    except Exception as e:
+        logging.warning("Could not read audio duration: %s", e)
+    return None
+
+
+def build_alignment(text: str, audio_path: str) -> tuple[dict | None, list, str]:
+    """Return (alignment or None, words, source). Never raises."""
+    try:
+        hooked = _try_whisperx(audio_path, text)
+        if hooked is not None:
+            return hooked, words_from_alignment(hooked), "whisperx"
+        duration = audio_duration_seconds(audio_path)
+        if duration is None:
+            return None, [], "unavailable"
+        alignment = estimate_alignment(text, duration)
+        return alignment, words_from_alignment(alignment), "duration_weighted"
+    except Exception as e:
+        logging.warning("Alignment failed, returning null: %s", e)
+        return None, [], "unavailable"

--- a/app/server.py
+++ b/app/server.py
@@ -1,4 +1,5 @@
 import os
+import base64
 import logging
 from flask import Flask, request, send_file, jsonify
 from gevent.pywsgi import WSGIServer
@@ -7,6 +8,7 @@ from argparse import ArgumentParser
 
 from tts_handler import TTSHandler
 from utils import require_api_key, AUDIO_FORMAT_MIME_TYPES
+from alignment import build_alignment
 
 # Initialize Flask app and load environment variables
 app = Flask(__name__)
@@ -137,6 +139,59 @@ def text_to_speech():
     except Exception as e:
         logging.error(f"Unhandled exception during TTS generation: {e}")
         return jsonify({"error": "Failed to generate speech"}), 500
+
+
+
+def _output_format_to_ext(output_format):
+    raw = (output_format or DEFAULT_RESPONSE_FORMAT or "mp3").lower()
+    if raw.startswith("wav") or raw == "pcm":
+        return "wav"
+    if raw.startswith("ogg") or raw.startswith("opus"):
+        return "ogg"
+    if raw.startswith("flac"):
+        return "flac"
+    return "mp3"
+
+
+@app.route("/v1/text-to-speech/<voice_id>/with-timestamps", methods=["POST"])
+@require_api_key
+def text_to_speech_with_timestamps(voice_id):
+    """ElevenLabs-shaped timestamps. Missing aligner software does not fail TTS."""
+    data = request.json or {}
+    text = data.get("text") or data.get("input")
+    if not text:
+        return jsonify({"error": "Missing 'text' in request body"}), 400
+
+    voice = voice_id or DEFAULT_VOICE
+    settings = data.get("voice_settings") or {}
+    speed = float(data.get("speed", settings.get("speed", DEFAULT_SPEED)))
+    response_format = _output_format_to_ext(
+        request.args.get("output_format") or data.get("response_format")
+    )
+    mime_type = AUDIO_FORMAT_MIME_TYPES.get(response_format.lower(), "audio/mpeg")
+
+    try:
+        output_file_path = tts_handler.generate_speech(
+            text=text, voice=voice, response_format=response_format, speed=speed
+        )
+        _temp_files_to_cleanup.add(output_file_path)
+        alignment, words, source = build_alignment(text, output_file_path)
+        with open(output_file_path, "rb") as fh:
+            audio_b64 = base64.b64encode(fh.read()).decode("ascii")
+        return jsonify({
+            "audio_base64": audio_b64,
+            "alignment": alignment,
+            "normalized_alignment": alignment,
+            "words": words,
+            "alignment_source": source,
+        })
+    except ValueError as e:
+        logging.error(f"ValueError during timestamped TTS: {e}")
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        logging.error(f"Unhandled exception during timestamped TTS: {e}")
+        return jsonify({"error": "Failed to generate speech"}), 500
+
 
 @app.route('/v1/models', methods=['GET'])
 @require_api_key

--- a/app/utils.py
+++ b/app/utils.py
@@ -47,16 +47,15 @@ def require_api_key(f):
         if not REQUIRE_API_KEY:
             return f(*args, **kwargs)
 
+        token = None
         auth_header = request.headers.get('Authorization')
-        if not auth_header:
+        if auth_header and auth_header.startswith('Bearer '):
+            token = auth_header.split('Bearer ', 1)[1]
+        if not token:
+            token = request.headers.get('xi-api-key')
+        if not token:
             logging.warning("Authorization header is missing.")
             return jsonify({"error": "Authorization header is missing"}), 401
-
-        if not auth_header.startswith('Bearer '):
-            logging.warning("Authorization header is malformed.")
-            return jsonify({"error": "Authorization header must start with 'Bearer'"}), 401
-
-        token = auth_header.split('Bearer ')[1]
 
         # Validate the token against the stored API key
         if token != API_KEY:

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,25 @@
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
+
+from alignment import estimate_alignment, words_from_alignment, build_alignment
+
+
+def test_estimate_alignment_covers_text_and_duration():
+    text = "Hello from F5."
+    al = estimate_alignment(text, 2.0)
+    assert "".join(al["characters"]) == text
+    assert len(al["character_start_times_seconds"]) == len(text)
+    assert al["character_start_times_seconds"][0] == 0.0
+    assert al["character_end_times_seconds"][-1] == 2.0
+    words = words_from_alignment(al)
+    assert [w["word"] for w in words] == ["Hello", "from", "F5"]
+
+
+def test_build_alignment_null_when_file_missing():
+    al, words, source = build_alignment("Hello", "Z:/definitely-missing.wav")
+    assert al is None
+    assert words == []
+    assert source == "unavailable"


### PR DESCRIPTION
## Summary
- Add POST /v1/text-to-speech/{voice}/with-timestamps
- /v1/audio/speech unchanged (raw audio)
- If aligner software is missing, still return audio with alignment null
- Duration-weighted fallback when duration can be read
- Accept xi-api-key as well as Bearer

## Test plan
- [x] pytest tests/test_alignment.py (2 passed)
- [ ] Existing /v1/audio/speech clients unchanged
- [ ] with-timestamps returns JSON when F5 can generate